### PR TITLE
Do not convert global model ids to lowercase

### DIFF
--- a/index.js
+++ b/index.js
@@ -127,13 +127,13 @@ module.exports = sails => {
                     sails.log.verbose('Exposing model \'' + modelDef.globalId + '\' globally');
                     global[modelDef.globalId] = modelClass;
                 }
-                sails.models[modelDef.globalId.toLowerCase()] = modelClass;
+                sails.models[modelDef.globalId] = modelClass;
             }
 
             for (modelName in models) {
                 modelDef = models[modelName];
                 this.setAssociation(modelDef);
-                this.setDefaultScope(modelDef, sails.models[modelDef.globalId.toLowerCase()]);
+                this.setDefaultScope(modelDef, sails.models[modelDef.globalId]);
             }
         },
 

--- a/index.js
+++ b/index.js
@@ -5,7 +5,8 @@ module.exports = sails => {
         defaults: {
             __configKey__: {
                 clsNamespace: 'sails-sequelize',
-                exposeToGlobal: true
+                exposeToGlobal: true,
+                enableSsaclAttributeRoles: false
             }
         },
         configure () {
@@ -77,14 +78,31 @@ module.exports = sails => {
                     connection.options.logging = sails.log[connection.options.logging];
                 }
 
+                let sequelize;
                 if (connection.url) {
-                    connections[connectionName] = new Sequelize(connection.url, connection.options);
+                    sequelize = new Sequelize(connection.url, connection.options);
                 } else {
-                    connections[connectionName] = new Sequelize(connection.database,
+                    sequelize = new Sequelize(connection.database,
                         connection.user,
                         connection.password,
                         connection.options);
                 }
+
+                if (sails.config[this.configKey].enableSsaclAttributeRoles) {
+                    try {
+                        // try to import ssacl-attribute-roles
+                        const ssaclAttributeRoles = require('ssacl-attribute-roles');
+                        ssaclAttributeRoles(sequelize);
+                    } catch (err) {
+                        if (err.code === 'MODULE_NOT_FOUND') {
+                            console.error('Please install "ssacl-attribute-roles" manually.')
+                        }
+                        // propagate error handling to sails
+                        throw err;
+                    }
+                }
+
+                connections[connectionName] = sequelize;
             }
 
             return connections;

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
   },
   "dependencies": {
     "continuation-local-storage": "^3.1.4",
-    "sequelize": "^4.2.1"
+    "sequelize": "^4.2.1",
+    "ssacl-attribute-roles": "^1.0.0"
   },
   "directories": {
     "test": "test"


### PR DESCRIPTION
The sequelize models should not be exposed all-lowercase.
This is against the way Sails Waterline exposes its models, and also against the examples on the official sequelize docs, where models are always referenced starting with an uppercase letter, for example [here](http://docs.sequelizejs.com/manual/tutorial/associations.html#hasone):

```js
const User = sequelize.define('user', {/* ... */})
const Project = sequelize.define('project', {/* ... */})

// OK. Now things get more complicated (not really visible to the user :)).
// First let's define a hasMany association
Project.hasMany(User, {as: 'Workers'})
```

This change allows the users of this hook to reference their models as they're used to.

