### PR TITLE
merge sails hook's model

### DIFF
--- a/index.js
+++ b/index.js
@@ -82,6 +82,9 @@ module.exports = sails => {
                     return next(err);
                 }
 
+                // merge sails hook's model before init all models.
+                models = sails.util.merge(models, sails.models || {});
+
                 self.defineModels(models, connections);
                 self.migrateSchema(next, connections, models);
             });


### PR DESCRIPTION
merge sails models again, in order to add hook`s model before init all models.