### PR TITLE
Feat: skip non-sequelize connections in datastore

### DIFF
--- a/index.js
+++ b/index.js
@@ -108,7 +108,7 @@ module.exports = sails => {
                 throw new Error('Default connection \'' + datastoreName + '\' not found in config/connections');
             }
 
-            for (connectionName in datastores) {
+            for (var connectionName = 0;  connectionName < datastores.length; connectionName++) {
                 connection = datastores[connectionName];
 
                 // Skip waterline and non sequelize connections

--- a/index.js
+++ b/index.js
@@ -111,8 +111,8 @@ module.exports = sails => {
             for (connectionName in datastores) {
                 connection = datastores[connectionName];
 
-                // Skip waterline connections
-                if (connection.adapter) {
+                // Skip waterline and non sequelize connections
+                if (connection.adapter || !connection.dialect) {
                     continue;
                 }
 


### PR DESCRIPTION
### Description, Motivation and Context
(Describe your changes in detail)
If there is a connection to a different type of database in the datastore, then the whole hook breaks. 
We can use the dialect to make sure that this is a sequelize connection config.

### What is the current behavior? 

A connection to a different type of database in the datastore breaks the whole app.

### What is the new behavior?
(if this is a feature change)
If no dialect is provided then the config is skipped.


### What kind of change does this PR introduce?
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
- [X] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [X] Overall test coverage is not decreased.
- [X] All new and existing tests passed.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
