### PR TITLE
Fix: Migration scope error

### DIFF
--- a/index.js
+++ b/index.js
@@ -250,7 +250,7 @@ module.exports = sails => {
 
                         // Skip waterline connections
                         if (connectionDescription.adapter) {
-                            continue;
+                            return;
                         }
 
                         sails.log.verbose('Migrating schema in \'' + connectionName + '\' connection');

--- a/index.js
+++ b/index.js
@@ -244,36 +244,39 @@ module.exports = sails => {
                 }
 
                 for (connectionName in datastores) {
-                    connectionDescription = datastores[connectionName];
+                    (function(){
+                        var _connectionName = connectionName;
+                        connectionDescription = datastores[_connectionName];
 
-                    // Skip waterline connections
-                    if (connectionDescription.adapter) {
-                        continue;
-                    }
+                        // Skip waterline connections
+                        if (connectionDescription.adapter) {
+                            continue;
+                        }
 
-                    sails.log.verbose('Migrating schema in \'' + connectionName + '\' connection');
+                        sails.log.verbose('Migrating schema in \'' + connectionName + '\' connection');
 
-                    if (connectionDescription.dialect === 'postgres') {
+                        if (connectionDescription.dialect === 'postgres') {
 
-                        syncTasks.push(connections[connectionName].showAllSchemas().then(schemas => {
-                            let modelName, modelDef, tableSchema;
+                            syncTasks.push(connections[_connectionName].showAllSchemas().then(schemas => {
+                                let modelName, modelDef, tableSchema;
 
-                            for (modelName in models) {
-                                modelDef = models[modelName];
-                                tableSchema = modelDef.options.schema || '';
+                                for (modelName in models) {
+                                    modelDef = models[modelName];
+                                    tableSchema = modelDef.options.schema || '';
 
-                                if (tableSchema !== '' && schemas.indexOf(tableSchema) < 0) { // there is no schema in db for model
-                                    connections[connectionName].createSchema(tableSchema);
-                                    schemas.push(tableSchema);
+                                    if (tableSchema !== '' && schemas.indexOf(tableSchema) < 0) { // there is no schema in db for model
+                                        connections[_connectionName].createSchema(tableSchema);
+                                        schemas.push(tableSchema);
+                                    }
                                 }
-                            }
 
-                            return connections[connectionName].sync({ force: forceSyncFlag, alter: alterFlag });
-                        }));
+                                return connections[_connectionName].sync({ force: forceSyncFlag, alter: alterFlag });
+                            }));
 
-                    } else {
-                        syncTasks.push(connections[connectionName].sync({ force: forceSyncFlag, alter: alterFlag }));
-                    }
+                        } else {
+                            syncTasks.push(connections[_connectionName].sync({ force: forceSyncFlag, alter: alterFlag }));
+                        }
+                    })();
                 }
 
                 Promise.all(syncTasks).then(() => next()).catch(e => next(e));

--- a/index.js
+++ b/index.js
@@ -245,8 +245,8 @@ module.exports = sails => {
 
                 for (connectionName in datastores) {
                     (function(){
-                        var _connectionName = connectionName;
-                        connectionDescription = datastores[_connectionName];
+                        var syncConnectionName = connectionName;
+                        connectionDescription = datastores[syncConnectionName];
 
                         // Skip waterline connections
                         if (connectionDescription.adapter) {
@@ -257,7 +257,7 @@ module.exports = sails => {
 
                         if (connectionDescription.dialect === 'postgres') {
 
-                            syncTasks.push(connections[_connectionName].showAllSchemas().then(schemas => {
+                            syncTasks.push(connections[syncConnectionName].showAllSchemas().then(schemas => {
                                 let modelName, modelDef, tableSchema;
 
                                 for (modelName in models) {
@@ -265,16 +265,16 @@ module.exports = sails => {
                                     tableSchema = modelDef.options.schema || '';
 
                                     if (tableSchema !== '' && schemas.indexOf(tableSchema) < 0) { // there is no schema in db for model
-                                        connections[_connectionName].createSchema(tableSchema);
+                                        connections[syncConnectionName].createSchema(tableSchema);
                                         schemas.push(tableSchema);
                                     }
                                 }
 
-                                return connections[_connectionName].sync({ force: forceSyncFlag, alter: alterFlag });
+                                return connections[syncConnectionName].sync({ force: forceSyncFlag, alter: alterFlag });
                             }));
 
                         } else {
-                            syncTasks.push(connections[_connectionName].sync({ force: forceSyncFlag, alter: alterFlag }));
+                            syncTasks.push(connections[syncConnectionName].sync({ force: forceSyncFlag, alter: alterFlag }));
                         }
                     })();
                 }


### PR DESCRIPTION
Fixes #61.

Fixes an error where when multiple datasources are defined, the sync migration is run against the last one multiple times.

<!--- Provide a general summary of your changes in the Title above -->

### Description, Motivation and Context
A scoping error causes schema migrations to be run multiple times against a single datasource.

### What is the current behavior? 
When iterating over the connections to perform the schema syncs, the name of the connection is not properly scopes, causing the incorrect scope name to be used when the deferred sync tasks are performed.

### What is the new behavior?
The sync tasks are generated in a new scope per iteration, so the correct connection name is used.

### What kind of change does this PR introduce?
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [x] Overall test coverage is not decreased.
- [x] All new and existing tests passed.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
