### PR TITLE
Restore default ability to globally set defaults for all models

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Also you can set some parameters in `config/sequelize.js` to override defaults.
 module.exports.sequelize = {
     "clsNamespace": "myAppCLSNamespace",
     "exposeToGlobal": true,
-    "mergeConfigModel": false //Restores default funcationality where you can have global / default values for all attributes
+    "mergeConfigModel": false //If set to an Object, allows to set default options for all models (Can be overriden in the model itself).
 };
 ```
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ Also you can set some parameters in `config/sequelize.js` to override defaults.
 ```
 module.exports.sequelize = {
     "clsNamespace": "myAppCLSNamespace",
-    "exposeToGlobal": true
+    "exposeToGlobal": true,
+    "mergeConfigModel": false //Restores default funcationality where you can have global / default values for all attributes
 };
 ```
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Also you can set some parameters in `config/sequelize.js` to override defaults.
 module.exports.sequelize = {
     "clsNamespace": "myAppCLSNamespace",
     "exposeToGlobal": true,
-    "mergeConfigModel": false //If set to an Object, allows to set default options for all models (Can be overriden in the model itself).
+    "modelDefaults": false //If set to an Object, allows to set default options for all models (Can be overriden in the model itself).
 };
 ```
 

--- a/index.js
+++ b/index.js
@@ -8,7 +8,8 @@ module.exports = sails => {
         defaults: {
             __configKey__: {
                 clsNamespace: 'sails-sequelize',
-                exposeToGlobal: true
+                exposeToGlobal: true,
+                mergeConfigModel: false
             }
         },
         configure () {
@@ -80,6 +81,12 @@ module.exports = sails => {
 
                 if (err) {
                     return next(err);
+                }
+
+                if(sails.config[this.configKey].mergeConfigModel) {
+                    Object.values(models).forEach((model) => {
+                        model = _.defaultsDeep(model, sails.config.models);
+                    });
                 }
 
                 self.defineModels(models, connections);

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ module.exports = sails => {
             __configKey__: {
                 clsNamespace: 'sails-sequelize',
                 exposeToGlobal: true,
-                mergeConfigModel: false
+                modelDefaults: false
             }
         },
         configure () {
@@ -83,9 +83,9 @@ module.exports = sails => {
                     return next(err);
                 }
 
-                if(sails.config[this.configKey].mergeConfigModel) {
+                if(sails.config[this.configKey].modelDefaults) {
                     Object.values(models).forEach((model) => {
-                        model = _.defaultsDeep(model, sails.config.models);
+                        model = _.defaultsDeep(model, sails.config[this.configKey].modelDefaults);
                     });
                 }
 


### PR DESCRIPTION
Allows to define global values to set for all models.

### Description, Motivation and Context
I found myself where I have a certain column for all of my Models, repeadetly defining them is not really DRY thus I've tried to copy original functionality of Waterlin where `attributes` defined in `sails.config.models` are merged into the Models themselves (Except I'm merging the seperate key `sails.config.sequelize.modelDefaults` to avoid breaking changes).

### What is the current behavior? 
Theres no way to globally define default values for models

### What is the new behavior?
Any key not defined in the Model that exists in `sails.config.sequelize.modelDefaults` will get merged into it

### What kind of change does this PR introduce?
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [ ] Overall test coverage is not decreased.
- [ ] All new and existing tests passed.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
